### PR TITLE
Correción de bugs

### DIFF
--- a/src/main/java/com/svalero/multidownloader/DownloadController.java
+++ b/src/main/java/com/svalero/multidownloader/DownloadController.java
@@ -61,7 +61,7 @@ public class DownloadController implements Initializable {
 
             downloadTask = new DownloadTask(urlText, file);
 
-            pbProgress.progressProperty().unbind();
+
             pbProgress.progressProperty().bind(downloadTask.progressProperty());
 
             downloadTask.stateProperty().addListener((observableValue, oldState, newState) -> {
@@ -87,8 +87,11 @@ public class DownloadController implements Initializable {
     }
 
     public void stop() {
-        if (downloadTask != null)
+        if (downloadTask != null) {
+            pbProgress.progressProperty().unbind();
+            pbProgress.setProgress(0);
             downloadTask.cancel();
+        }
     }
 
     public void delete() {
@@ -105,7 +108,14 @@ public class DownloadController implements Initializable {
         if (delay.getText().equals("")) {
             return 0;
         } else {
-            return Integer.parseInt(delay.getText());
+            try {
+                if (Integer.parseInt(delay.getText()) <= 0) {
+                    return 0;
+                }
+                return Integer.parseInt(delay.getText());
+            } catch (NumberFormatException nfe) {
+                return 0;
+            }
         }
     }
 }

--- a/src/main/java/com/svalero/multidownloader/DownloadTask.java
+++ b/src/main/java/com/svalero/multidownloader/DownloadTask.java
@@ -53,6 +53,7 @@ public class DownloadTask extends Task<Integer> {
 
             if (isCancelled()) {
                 logger.trace("Descarga " + url.toString() + " cancelada");
+                updateMessage("");
                 fileOutputStream.close();
                 return null;
             }


### PR DESCRIPTION
Corregido el bug de  introducir un tiempo de espera no numérico. Ahora se interpreta como 0.
Si se cancela una descarga, la barra de progreso se vacía y el texto con el porcentaje de progreso desaparece.